### PR TITLE
Expand VCF allele count calculation method

### DIFF
--- a/standardize_mutation_data.py
+++ b/standardize_mutation_data.py
@@ -1217,6 +1217,18 @@ def resolve_vcf_allele_depth_values(mapped_sample_format_data, vcf_alleles, vari
         message = "DP could not be resolved for current record in VCF: %s - using default value of empty string..." % (str(vcf_data))
         print_warning(message)
 
+    # if depth has been resolved but not ref_count, alt_count then calculate the counts
+    # if allele frequency vcf field "AF" exists
+    if (
+        not is_missing_vcf_data_value(depth) and not is_missing_vcf_data_value(mapped_sample_format_data["AF"])
+        and (is_missing_vcf_data_value(ref_count) or is_missing_vcf_data_value(alt_count))
+        ):
+        # check if ref count or alt count are still missing but AF VCF field is available
+        if is_missing_vcf_data_value(ref_count):
+            ref_count = str(round(float(depth) * float(mapped_sample_format_data["AF"])))
+        if is_missing_vcf_data_value(alt_count) and not is_missing_vcf_data_value(ref_count):
+            alt_count = str(round(float(depth) - float(ref_count)))
+
     return (ref_count, alt_count, depth)
 
 


### PR DESCRIPTION
Calculate VCF allele counts if these criteria are met
- VCF depth is known
- VCF "AF" (allele frequency) is provided

If 'resolve_vcf_allele_depth_values()' method cannot resolve the allele counts by other means then
fall back on calculating from VCF depth and VCF AF values.

Formulas:
1. depth = ref_count + alt_count
2. ref_count = depth * allele_freq

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>