### PR TITLE
Improve tumor / nomal sample column detection in vcf files

### DIFF
--- a/standardize_mutation_data.py
+++ b/standardize_mutation_data.py
@@ -855,8 +855,17 @@ def get_vcf_sample_and_normal_ids(filename):
         tumor_sample_data_col_name = case_ids_cols[0]
         matched_normal_sample_id = "NORMAL"
     elif sample_columns_num == 2:
-        tumor_sample_data_col_name = case_ids_cols[0]
-        matched_normal_sample_id = case_ids_cols[1]
+        if "TUMOR" in case_ids_cols:
+            tumor_sample_data_col_name = "TUMOR"
+            case_ids_cols.remove("TUMOR")
+            matched_normal_sample_id = case_ids_cols[0]
+        elif "NORMAL" in case_ids_cols:
+            matched_normal_sample_id = "NORMAL"
+            case_ids_cols.remove("NORMAL")
+            tumor_sample_data_col_name = case_ids_cols[0]
+        else:
+            tumor_sample_data_col_name = case_ids_cols[0]
+            matched_normal_sample_id = case_ids_cols[1]
     else:
         raise Exception(f"Can't detect the tumor sample column among {sample_columns_num} columns")
 

--- a/standardize_mutation_data.py
+++ b/standardize_mutation_data.py
@@ -852,6 +852,8 @@ def get_vcf_sample_and_normal_ids(filename):
     if sample_columns_num == 0:
         raise Exception("No sample column found")
     if sample_columns_num == 1:
+        if case_ids_cols[0] == "NORMAL":
+            raise Exception("There is only one sample column and it has NORMAL label. No tumor sample column present.")
         tumor_sample_data_col_name = case_ids_cols[0]
         matched_normal_sample_id = "NORMAL"
     elif sample_columns_num == 2:

--- a/standardize_mutation_data.py
+++ b/standardize_mutation_data.py
@@ -848,6 +848,8 @@ def get_vcf_sample_and_normal_ids(filename):
             break
     # get the case id columns based on which columns in the header are not part of the fixed VCF header
     case_ids_cols = [col for col in vcf_file_header if col not in VCF_FIXED_HEADER_NON_CASE_IDS]
+    if len(case_ids_cols) == 0:
+        raise Exception("No sample column found")
     if len(case_ids_cols) == 1:
         tumor_sample_data_col_name = case_ids_cols[0]
         matched_normal_sample_id = "NORMAL"

--- a/standardize_mutation_data.py
+++ b/standardize_mutation_data.py
@@ -842,12 +842,18 @@ def get_vcf_sample_and_normal_ids(filename):
 
 
     vcf_file_header = []
+    vcf_meta_header = dict()
     for line in extract_file_data(filename):
         if line.startswith("#CHROM"):
             vcf_file_header = list(map(str.strip, line.replace("#", "").split("\t")))
             break
+        elif line.startswith("##"):
+            key, val = list(map(str.strip, line.replace("##", "").split("=")))
+            vcf_meta_header[key] = val
     # get the case id columns based on which columns in the header are not part of the fixed VCF header
     case_ids_cols = [col for col in vcf_file_header if col not in VCF_FIXED_HEADER_NON_CASE_IDS]
+    if 'tumor_sample' in vcf_meta_header:
+        return (vcf_meta_header['tumor_sample'], vcf_meta_header['tumor_sample'], vcf_meta_header['normal_sample'] if 'normal_sample' in vcf_meta_header else "NORMAL")
     sample_columns_num = len(case_ids_cols)
     if sample_columns_num == 0:
         raise Exception("No sample column found")

--- a/standardize_mutation_data.py
+++ b/standardize_mutation_data.py
@@ -884,9 +884,6 @@ def get_vcf_sample_and_normal_ids(filename):
     elif len(case_ids_cols) == 2:
         tumor_sample_data_col_name = case_ids_cols[0]
         matched_normal_sample_id = case_ids_cols[1]
-    else:
-        tumor_sample_data_col_name = "TUMOR"
-        matched_normal_sample_id = "NORMAL"
 
     if tumor_sample_data_col_name == "TUMOR":
         tumor_sample_id = os.path.basename(filename).replace(".vcf", "")

--- a/standardize_mutation_data.py
+++ b/standardize_mutation_data.py
@@ -869,7 +869,7 @@ def get_vcf_sample_and_normal_ids(filename):
             tumor_sample_data_col_name = case_ids_cols[0]
             matched_normal_sample_id = case_ids_cols[1]
     else:
-        raise Exception(f"Can't detect the tumor sample column among {sample_columns_num} columns")
+        raise Exception(f"Expected max 2 sample columns for tumor and normal sample. But found {sample_columns_num} columns.")
 
     if tumor_sample_data_col_name == "TUMOR":
         tumor_sample_id = os.path.basename(filename).replace(".vcf", "")

--- a/standardize_mutation_data.py
+++ b/standardize_mutation_data.py
@@ -852,6 +852,10 @@ def get_vcf_sample_and_normal_ids(filename):
             vcf_meta_header[key] = val
     # get the case id columns based on which columns in the header are not part of the fixed VCF header
     case_ids_cols = [col for col in vcf_file_header if col not in VCF_FIXED_HEADER_NON_CASE_IDS]
+    if 'normal_sample' in vcf_meta_header and vcf_meta_header['normal_sample'] not in case_ids_cols:
+        raise Exception(f"There is normal_sample={vcf_meta_header['normal_sample']} in the header, but no respective column found.")
+    if 'tumor_sample' in vcf_meta_header and vcf_meta_header['tumor_sample'] not in case_ids_cols:
+        raise Exception(f"There is tumor_sample={vcf_meta_header['tumor_sample']} in the header, but no respective column found.")
     if 'tumor_sample' in vcf_meta_header:
         return (vcf_meta_header['tumor_sample'], vcf_meta_header['tumor_sample'], vcf_meta_header['normal_sample'] if 'normal_sample' in vcf_meta_header else "NORMAL")
     sample_columns_num = len(case_ids_cols)

--- a/standardize_mutation_data.py
+++ b/standardize_mutation_data.py
@@ -857,8 +857,6 @@ def get_vcf_sample_and_normal_ids(filename):
         raise Exception(f"There is normal_sample={vcf_meta_header['normal_sample']} in the header, but no respective column found.")
     if 'tumor_sample' in vcf_meta_header and vcf_meta_header['tumor_sample'] not in case_ids_cols:
         raise Exception(f"There is tumor_sample={vcf_meta_header['tumor_sample']} in the header, but no respective column found.")
-    if 'tumor_sample' in vcf_meta_header:
-        return (vcf_meta_header['tumor_sample'], vcf_meta_header['tumor_sample'], vcf_meta_header['normal_sample'] if 'normal_sample' in vcf_meta_header else "NORMAL")
     sample_columns_num = len(case_ids_cols)
     if sample_columns_num == 0:
         raise Exception("No sample column found")
@@ -867,26 +865,41 @@ def get_vcf_sample_and_normal_ids(filename):
     if sample_columns_num > 2:
         raise Exception(f"Expected max 2 sample columns for tumor and normal sample. But found {sample_columns_num} columns.")
 
-    if sample_columns_num == 1:
-        tumor_sample_data_col_name = case_ids_cols[0]
-        matched_normal_sample_id = "NORMAL"
-    elif sample_columns_num == 2:
-        if "TUMOR" in case_ids_cols:
-            tumor_sample_data_col_name = "TUMOR"
-            case_ids_cols.remove("TUMOR")
-            matched_normal_sample_id = case_ids_cols[0]
-        elif "NORMAL" in case_ids_cols:
-            matched_normal_sample_id = "NORMAL"
-            case_ids_cols.remove("NORMAL")
-            tumor_sample_data_col_name = case_ids_cols[0]
-        else:
-            tumor_sample_data_col_name = case_ids_cols[0]
-            matched_normal_sample_id = case_ids_cols[1]
+    tumor_sample_data_col_name = None
+    tumor_sample_id = None
+    matched_normal_sample_id = None
 
-    if tumor_sample_data_col_name == "TUMOR":
+    if 'tumor_sample' in vcf_meta_header:
+        tumor_sample_data_col_name = vcf_meta_header['tumor_sample']
+        case_ids_cols.remove(tumor_sample_data_col_name)
+
+    if 'normal_sample' in vcf_meta_header:
+        matched_normal_sample_id = vcf_meta_header['normal_sample']
+        case_ids_cols.remove(matched_normal_sample_id)
+
+    if tumor_sample_data_col_name is None and 'TUMOR' in case_ids_cols:
+        tumor_sample_data_col_name = 'TUMOR'
+        case_ids_cols.remove(tumor_sample_data_col_name)
         tumor_sample_id = os.path.basename(filename).replace(".vcf", "")
-    else:
+
+    if matched_normal_sample_id is None and 'NORMAL' in case_ids_cols:
+        matched_normal_sample_id = 'NORMAL'
+        case_ids_cols.remove(matched_normal_sample_id)
+
+    if tumor_sample_data_col_name is None and len(case_ids_cols) > 0:
+        tumor_sample_data_col_name = case_ids_cols[0]
+        case_ids_cols.remove(tumor_sample_data_col_name)
+
+    if matched_normal_sample_id is None and len(case_ids_cols) > 0:
+        matched_normal_sample_id = case_ids_cols[0]
+        case_ids_cols.remove(matched_normal_sample_id)
+
+    if tumor_sample_id is None:
         tumor_sample_id = tumor_sample_data_col_name
+
+    if matched_normal_sample_id is None:
+        matched_normal_sample_id = 'NORMAL'
+
     return (tumor_sample_id, tumor_sample_data_col_name, matched_normal_sample_id)
 
 def resolve_vcf_allele(vcf_data):

--- a/standardize_mutation_data.py
+++ b/standardize_mutation_data.py
@@ -848,17 +848,17 @@ def get_vcf_sample_and_normal_ids(filename):
             break
     # get the case id columns based on which columns in the header are not part of the fixed VCF header
     case_ids_cols = [col for col in vcf_file_header if col not in VCF_FIXED_HEADER_NON_CASE_IDS]
-    if len(case_ids_cols) == 0:
+    sample_columns_num = len(case_ids_cols)
+    if sample_columns_num == 0:
         raise Exception("No sample column found")
-    if len(case_ids_cols) == 1:
+    if sample_columns_num == 1:
         tumor_sample_data_col_name = case_ids_cols[0]
         matched_normal_sample_id = "NORMAL"
-    elif len(case_ids_cols) == 2:
+    elif sample_columns_num == 2:
         tumor_sample_data_col_name = case_ids_cols[0]
         matched_normal_sample_id = case_ids_cols[1]
     else:
-        tumor_sample_data_col_name = "TUMOR"
-        matched_normal_sample_id = "NORMAL"
+        raise Exception(f"Can't detect the tumor sample column among {sample_columns_num} columns")
 
     if tumor_sample_data_col_name == "TUMOR":
         tumor_sample_id = os.path.basename(filename).replace(".vcf", "")

--- a/standardize_mutation_data.py
+++ b/standardize_mutation_data.py
@@ -852,6 +852,7 @@ def get_vcf_sample_and_normal_ids(filename):
             vcf_meta_header[key] = val
     # get the case id columns based on which columns in the header are not part of the fixed VCF header
     case_ids_cols = [col for col in vcf_file_header if col not in VCF_FIXED_HEADER_NON_CASE_IDS]
+
     if 'normal_sample' in vcf_meta_header and vcf_meta_header['normal_sample'] not in case_ids_cols:
         raise Exception(f"There is normal_sample={vcf_meta_header['normal_sample']} in the header, but no respective column found.")
     if 'tumor_sample' in vcf_meta_header and vcf_meta_header['tumor_sample'] not in case_ids_cols:
@@ -861,9 +862,12 @@ def get_vcf_sample_and_normal_ids(filename):
     sample_columns_num = len(case_ids_cols)
     if sample_columns_num == 0:
         raise Exception("No sample column found")
-    if sample_columns_num == 1:
-        if case_ids_cols[0] == "NORMAL":
+    if sample_columns_num == 1 and case_ids_cols[0] == "NORMAL":
             raise Exception("There is only one sample column and it has NORMAL label. No tumor sample column present.")
+    if sample_columns_num > 2:
+        raise Exception(f"Expected max 2 sample columns for tumor and normal sample. But found {sample_columns_num} columns.")
+
+    if sample_columns_num == 1:
         tumor_sample_data_col_name = case_ids_cols[0]
         matched_normal_sample_id = "NORMAL"
     elif sample_columns_num == 2:
@@ -878,8 +882,6 @@ def get_vcf_sample_and_normal_ids(filename):
         else:
             tumor_sample_data_col_name = case_ids_cols[0]
             matched_normal_sample_id = case_ids_cols[1]
-    else:
-        raise Exception(f"Expected max 2 sample columns for tumor and normal sample. But found {sample_columns_num} columns.")
 
     if tumor_sample_data_col_name == "TUMOR":
         tumor_sample_id = os.path.basename(filename).replace(".vcf", "")

--- a/standardize_mutation_data.py
+++ b/standardize_mutation_data.py
@@ -848,8 +848,8 @@ def get_vcf_sample_and_normal_ids(filename):
             vcf_file_header = list(map(str.strip, line.replace("#", "").split("\t")))
             break
         elif line.startswith("##"):
-            key, val = list(map(str.strip, line.replace("##", "").split("=")))
-            vcf_meta_header[key] = val
+            key, *val_splits = list(map(str.strip, line.replace("##", "").split("=")))
+            vcf_meta_header[key] = "=".join(val_splits)
     # get the case id columns based on which columns in the header are not part of the fixed VCF header
     case_ids_cols = [col for col in vcf_file_header if col not in VCF_FIXED_HEADER_NON_CASE_IDS]
 

--- a/standardize_mutation_data_tests.py
+++ b/standardize_mutation_data_tests.py
@@ -176,5 +176,19 @@ class StandardizeMutationDataTests(unittest.TestCase):
         self.assertEqual('NORMAL', maf_row['Tumor_Sample_Barcode'])
         self.assertEqual('TUMOR', maf_row['Matched_Norm_Sample_Barcode'])
 
+    def test_extract_vcf_data_from_file_multiple_equals_in_header(self):
+        _, vcf = tempfile.mkstemp()
+        with open(vcf, 'w') as f:
+           f.write(
+            '##tumor_sample=A=B\n'
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tA=B\n"
+            "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\t0|0:48:1:51,51\n"
+           )
+        maf_data = extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
+        self.assertEqual(1, len(maf_data))
+        maf_row = maf_data[0]
+        self.assertEqual('A=B', maf_row['Tumor_Sample_Barcode'])
+        self.assertEqual('NORMAL', maf_row['Matched_Norm_Sample_Barcode'])
+
 if __name__=='__main__':
     unittest.main()

--- a/standardize_mutation_data_tests.py
+++ b/standardize_mutation_data_tests.py
@@ -107,5 +107,30 @@ class StandardizeMutationDataTests(unittest.TestCase):
         self.assertEqual('S2', maf_row['Tumor_Sample_Barcode'])
         self.assertEqual('S1', maf_row['Matched_Norm_Sample_Barcode'])
 
+    def test_extract_vcf_data_from_file_normal_sample_refers_to_non_existing_column(self):
+        _, vcf = tempfile.mkstemp()
+        with open(vcf, 'w') as f:
+           f.write(
+            '##normal_sample=S1\n'
+            '##tumor_sample=S2\n'
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS2\n"
+            "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\t0|0:48:1:51,51\n"
+           )
+        with self.assertRaises(Exception) as exc:
+            extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
+        self.assertEqual("There is normal_sample=S1 in the header, but no respective column found.", str(exc.exception))
+
+    def test_extract_vcf_data_from_file_tumor_sample_refers_to_non_existing_column(self):
+        _, vcf = tempfile.mkstemp()
+        with open(vcf, 'w') as f:
+           f.write(
+            '##normal_sample=S1\n'
+            '##tumor_sample=S2\n'
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS1\n"
+            "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\t0|0:48:1:51,51\n"
+           )
+        with self.assertRaises(Exception) as exc:
+            extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
+        self.assertEqual("There is tumor_sample=S2 in the header, but no respective column found.", str(exc.exception))
 if __name__=='__main__':
     unittest.main()

--- a/standardize_mutation_data_tests.py
+++ b/standardize_mutation_data_tests.py
@@ -49,13 +49,24 @@ class StandardizeMutationDataTests(unittest.TestCase):
            f.write(
             "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tTUMOR\n"
             "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\t0|0:48:1:51,51\n"
-           ) 
+           )
         maf_data = extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
         self.assertEqual(1, len(maf_data)) 
         maf_row = maf_data[0]
         self.assertTrue(maf_row['Tumor_Sample_Barcode']) 
         self.assertNotEqual('S1', maf_row['Tumor_Sample_Barcode']) 
         self.assertEqual('NORMAL', maf_row['Matched_Norm_Sample_Barcode']) 
+
+    def test_extract_vcf_data_from_file_3_samples(self):
+        _, vcf = tempfile.mkstemp()
+        with open(vcf, 'w') as f:
+           f.write(
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS1\tS2\tS3\n"
+            "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\t0|0:48:1:51,51\t1|0:48:8:51,51\t1|0:48:8:51,51\n"
+           )
+        with self.assertRaises(Exception) as exc:
+            extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
+        self.assertEqual("Can't detect the tumor sample column among 3 columns", str(exc.exception))
 
 if __name__=='__main__':
     unittest.main()

--- a/standardize_mutation_data_tests.py
+++ b/standardize_mutation_data_tests.py
@@ -132,5 +132,49 @@ class StandardizeMutationDataTests(unittest.TestCase):
         with self.assertRaises(Exception) as exc:
             extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
         self.assertEqual("There is tumor_sample=S2 in the header, but no respective column found.", str(exc.exception))
+
+    def test_extract_vcf_data_from_file_tumor_sample_out_of_2_samples_specified_in_header(self):
+        _, vcf = tempfile.mkstemp()
+        with open(vcf, 'w') as f:
+           f.write(
+            '##tumor_sample=S2\n'
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS1\tS2\n"
+            "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\t0|0:48:1:51,51\t1|0:48:8:51,51\n"
+           )
+        maf_data = extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
+        self.assertEqual(1, len(maf_data))
+        maf_row = maf_data[0]
+        self.assertEqual('S2', maf_row['Tumor_Sample_Barcode'])
+        self.assertEqual('S1', maf_row['Matched_Norm_Sample_Barcode'])
+
+    def test_extract_vcf_data_from_file_normal_sample_out_of_2_samples_specified_in_header(self):
+        _, vcf = tempfile.mkstemp()
+        with open(vcf, 'w') as f:
+           f.write(
+            '##normal_sample=S1\n'
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS1\tS2\n"
+            "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\t0|0:48:1:51,51\t1|0:48:8:51,51\n"
+           )
+        maf_data = extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
+        self.assertEqual(1, len(maf_data))
+        maf_row = maf_data[0]
+        self.assertEqual('S2', maf_row['Tumor_Sample_Barcode'])
+        self.assertEqual('S1', maf_row['Matched_Norm_Sample_Barcode'])
+
+    def test_extract_vcf_data_from_file_header_samples_have_precedence_over_the_rest_of_strategies(self):
+        _, vcf = tempfile.mkstemp()
+        with open(vcf, 'w') as f:
+           f.write(
+            '##normal_sample=TUMOR\n'
+            '##tumor_sample=NORMAL\n'
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tTUMOR\tNORMAL\n"
+            "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\t0|0:48:1:51,51\t1|0:48:8:51,51\n"
+           )
+        maf_data = extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
+        self.assertEqual(1, len(maf_data))
+        maf_row = maf_data[0]
+        self.assertEqual('NORMAL', maf_row['Tumor_Sample_Barcode'])
+        self.assertEqual('TUMOR', maf_row['Matched_Norm_Sample_Barcode'])
+
 if __name__=='__main__':
     unittest.main()

--- a/standardize_mutation_data_tests.py
+++ b/standardize_mutation_data_tests.py
@@ -92,5 +92,20 @@ class StandardizeMutationDataTests(unittest.TestCase):
             extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
         self.assertEqual("There is only one sample column and it has NORMAL label. No tumor sample column present.", str(exc.exception))
 
+    def test_extract_vcf_data_from_file_2_samples_specified_in_header(self):
+        _, vcf = tempfile.mkstemp()
+        with open(vcf, 'w') as f:
+           f.write(
+            '##normal_sample=S1\n'
+            '##tumor_sample=S2\n'
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS1\tS2\n"
+            "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\t0|0:48:1:51,51\t1|0:48:8:51,51\n"
+           )
+        maf_data = extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
+        self.assertEqual(1, len(maf_data))
+        maf_row = maf_data[0]
+        self.assertEqual('S2', maf_row['Tumor_Sample_Barcode'])
+        self.assertEqual('S1', maf_row['Matched_Norm_Sample_Barcode'])
+
 if __name__=='__main__':
     unittest.main()

--- a/standardize_mutation_data_tests.py
+++ b/standardize_mutation_data_tests.py
@@ -81,5 +81,16 @@ class StandardizeMutationDataTests(unittest.TestCase):
         self.assertNotEqual('NORMAL', maf_row['Tumor_Sample_Barcode'])
         self.assertEqual('NORMAL', maf_row['Matched_Norm_Sample_Barcode'])
 
+    def test_extract_vcf_data_from_file_1_normal_sample(self):
+        _, vcf = tempfile.mkstemp()
+        with open(vcf, 'w') as f:
+           f.write(
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNORMAL\n"
+            "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\t0|0:48:1:51,51\n"
+           )
+        with self.assertRaises(Exception) as exc:
+            extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
+        self.assertEqual("There is only one sample column and it has NORMAL label. No tumor sample column present.", str(exc.exception))
+
 if __name__=='__main__':
     unittest.main()

--- a/standardize_mutation_data_tests.py
+++ b/standardize_mutation_data_tests.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import unittest
+import tempfile
+from standardize_mutation_data import extract_vcf_data_from_file
+
+class StandardizeMutationDataTests(unittest.TestCase):
+
+    def test_extract_vcf_data_from_file_1_sample(self):
+        _, vcf = tempfile.mkstemp()
+        with open(vcf, 'w') as f:
+           f.write(
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS1\n"
+            "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\t0|0:48:1:51,51\n"
+           ) 
+        maf_data = extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
+        self.assertEqual(1, len(maf_data)) 
+        maf_row = maf_data[0]
+        self.assertEqual('S1', maf_row['Tumor_Sample_Barcode']) 
+        self.assertEqual('NORMAL', maf_row['Matched_Norm_Sample_Barcode']) 
+
+    def test_extract_vcf_data_from_file_2_samples(self):
+        _, vcf = tempfile.mkstemp()
+        with open(vcf, 'w') as f:
+           f.write(
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS1\tS2\n"
+            "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\t0|0:48:1:51,51\t1|0:48:8:51,51\n"
+           ) 
+        maf_data = extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
+        self.assertEqual(1, len(maf_data)) 
+        maf_row = maf_data[0]
+        self.assertEqual('S1', maf_row['Tumor_Sample_Barcode']) 
+        self.assertEqual('S2', maf_row['Matched_Norm_Sample_Barcode']) 
+
+    def test_extract_vcf_data_from_file_tumor(self):
+        _, vcf = tempfile.mkstemp()
+        with open(vcf, 'w') as f:
+           f.write(
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tTUMOR\n"
+            "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\t0|0:48:1:51,51\n"
+           ) 
+        maf_data = extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
+        self.assertEqual(1, len(maf_data)) 
+        maf_row = maf_data[0]
+        self.assertTrue(maf_row['Tumor_Sample_Barcode']) 
+        self.assertNotEqual('S1', maf_row['Tumor_Sample_Barcode']) 
+        self.assertEqual('NORMAL', maf_row['Matched_Norm_Sample_Barcode']) 
+
+if __name__=='__main__':
+    unittest.main()

--- a/standardize_mutation_data_tests.py
+++ b/standardize_mutation_data_tests.py
@@ -6,6 +6,17 @@ from standardize_mutation_data import extract_vcf_data_from_file
 
 class StandardizeMutationDataTests(unittest.TestCase):
 
+    def test_extract_vcf_data_from_file_no_samples(self):
+        _, vcf = tempfile.mkstemp()
+        with open(vcf, 'w') as f:
+           f.write(
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\n"
+            "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\n"
+           )
+        with self.assertRaises(Exception) as exc:
+            extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
+        self.assertEqual("No sample column found", str(exc.exception))
+
     def test_extract_vcf_data_from_file_1_sample(self):
         _, vcf = tempfile.mkstemp()
         with open(vcf, 'w') as f:

--- a/standardize_mutation_data_tests.py
+++ b/standardize_mutation_data_tests.py
@@ -66,7 +66,7 @@ class StandardizeMutationDataTests(unittest.TestCase):
            )
         with self.assertRaises(Exception) as exc:
             extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
-        self.assertEqual("Can't detect the tumor sample column among 3 columns", str(exc.exception))
+        self.assertEqual("Expected max 2 sample columns for tumor and normal sample. But found 3 columns.", str(exc.exception))
 
     def test_extract_vcf_data_from_file_tumor_normal_swap(self):
         _, vcf = tempfile.mkstemp()

--- a/standardize_mutation_data_tests.py
+++ b/standardize_mutation_data_tests.py
@@ -68,5 +68,18 @@ class StandardizeMutationDataTests(unittest.TestCase):
             extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
         self.assertEqual("Can't detect the tumor sample column among 3 columns", str(exc.exception))
 
+    def test_extract_vcf_data_from_file_tumor_normal_swap(self):
+        _, vcf = tempfile.mkstemp()
+        with open(vcf, 'w') as f:
+           f.write(
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNORMAL\tTUMOR\n"
+            "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\t0|0:48:1:51,51\t1|0:48:8:51,51\n"
+           )
+        maf_data = extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
+        self.assertEqual(1, len(maf_data))
+        maf_row = maf_data[0]
+        self.assertNotEqual('NORMAL', maf_row['Tumor_Sample_Barcode'])
+        self.assertEqual('NORMAL', maf_row['Matched_Norm_Sample_Barcode'])
+
 if __name__=='__main__':
     unittest.main()

--- a/test/standardize_mutation_data_tests.py
+++ b/test/standardize_mutation_data_tests.py
@@ -69,6 +69,8 @@ class StandardizeMutationDataTests(unittest.TestCase):
         self.assertEqual("Expected max 2 sample columns for tumor and normal sample. But found 3 columns.", str(exc.exception))
 
     def test_extract_vcf_data_from_file_tumor_normal_swap(self):
+        # this test is just showing that the name of the columns does not matter...it will be the order
+        # that matters in this case: first column is seen as Tumor_Sample_Barcode, second column as Matched_Norm_Sample_Barcode:
         _, vcf = tempfile.mkstemp()
         with open(vcf, 'w') as f:
            f.write(
@@ -78,8 +80,8 @@ class StandardizeMutationDataTests(unittest.TestCase):
         maf_data = extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
         self.assertEqual(1, len(maf_data))
         maf_row = maf_data[0]
-        self.assertNotEqual('NORMAL', maf_row['Tumor_Sample_Barcode'])
-        self.assertEqual('NORMAL', maf_row['Matched_Norm_Sample_Barcode'])
+        self.assertEqual('NORMAL', maf_row['Tumor_Sample_Barcode'])
+        self.assertEqual('TUMOR', maf_row['Matched_Norm_Sample_Barcode'])
 
     def test_extract_vcf_data_from_file_1_normal_sample(self):
         _, vcf = tempfile.mkstemp()
@@ -99,6 +101,23 @@ class StandardizeMutationDataTests(unittest.TestCase):
             '##normal_sample=S1\n'
             '##tumor_sample=S2\n'
             "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS1\tS2\n"
+            "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\t0|0:48:1:51,51\t1|0:48:8:51,51\n"
+           )
+        maf_data = extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
+        self.assertEqual(1, len(maf_data))
+        maf_row = maf_data[0]
+        self.assertEqual('S2', maf_row['Tumor_Sample_Barcode'])
+        self.assertEqual('S1', maf_row['Matched_Norm_Sample_Barcode'])
+
+    def test_extract_vcf_data_from_file_2_samples_specified_in_header_reversed_order(self):
+        # same as above, but with column order reversed in CHROM header line...should still give the same result, just
+        # to show that it is really reading from header and not from column order:
+        _, vcf = tempfile.mkstemp()
+        with open(vcf, 'w') as f:
+           f.write(
+            '##normal_sample=S1\n'
+            '##tumor_sample=S2\n'
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS2\tS1\n"
             "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\t0|0:48:1:51,51\t1|0:48:8:51,51\n"
            )
         maf_data = extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
@@ -133,34 +152,6 @@ class StandardizeMutationDataTests(unittest.TestCase):
             extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
         self.assertEqual("There is tumor_sample=S2 in the header, but no respective column found.", str(exc.exception))
 
-    def test_extract_vcf_data_from_file_tumor_sample_out_of_2_samples_specified_in_header(self):
-        _, vcf = tempfile.mkstemp()
-        with open(vcf, 'w') as f:
-           f.write(
-            '##tumor_sample=S2\n'
-            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS1\tS2\n"
-            "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\t0|0:48:1:51,51\t1|0:48:8:51,51\n"
-           )
-        maf_data = extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
-        self.assertEqual(1, len(maf_data))
-        maf_row = maf_data[0]
-        self.assertEqual('S2', maf_row['Tumor_Sample_Barcode'])
-        self.assertEqual('S1', maf_row['Matched_Norm_Sample_Barcode'])
-
-    def test_extract_vcf_data_from_file_normal_sample_out_of_2_samples_specified_in_header(self):
-        _, vcf = tempfile.mkstemp()
-        with open(vcf, 'w') as f:
-           f.write(
-            '##normal_sample=S1\n'
-            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS1\tS2\n"
-            "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\t0|0:48:1:51,51\t1|0:48:8:51,51\n"
-           )
-        maf_data = extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
-        self.assertEqual(1, len(maf_data))
-        maf_row = maf_data[0]
-        self.assertEqual('S2', maf_row['Tumor_Sample_Barcode'])
-        self.assertEqual('S1', maf_row['Matched_Norm_Sample_Barcode'])
-
     def test_extract_vcf_data_from_file_header_samples_have_precedence_over_the_rest_of_strategies(self):
         _, vcf = tempfile.mkstemp()
         with open(vcf, 'w') as f:
@@ -184,11 +175,9 @@ class StandardizeMutationDataTests(unittest.TestCase):
             "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tA=B\n"
             "20\t14370\trs6054257\tG\tA\t29\tPASS\tNS=3;DP=14;AF=0.5;DB;H2\tGT:GQ:DP:HQ\t0|0:48:1:51,51\n"
            )
-        maf_data = extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
-        self.assertEqual(1, len(maf_data))
-        maf_row = maf_data[0]
-        self.assertEqual('A=B', maf_row['Tumor_Sample_Barcode'])
-        self.assertEqual('NORMAL', maf_row['Matched_Norm_Sample_Barcode'])
+        with self.assertRaises(Exception) as exc:
+            extract_vcf_data_from_file(vcf, 'center name 1', 'sequence source 1')
+        self.assertIn("The tumor_sample and normal_sample are expected together", str(exc.exception))
 
 if __name__=='__main__':
     unittest.main()


### PR DESCRIPTION
Use tumor/normal sample variables in the vcf meta header if they are present.

```
##normal_sample=S1234N
##tumor_sample=S1234T
```

These variable are not part of the VCF specification but used widely by gatk. See https://github.com/broadinstitute/gatk/search?q=%23%23normal_sample%3D

See the ticket form more details https://github.com/genome-nexus/annotation-tools/issues/47